### PR TITLE
Announce the collapse of an enum expansion dropped at a join

### DIFF
--- a/src/owned_pcg/impl/local/join.rs
+++ b/src/owned_pcg/impl/local/join.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DebugLines,
+    DebugLines, Weaken,
     action::{BorrowPcgAction, PcgAction},
     borrow_pcg::action::LabelPlaceReason,
     capability_gte,
@@ -45,16 +45,16 @@ enum JoinExpandedPlaceResult<'tcx> {
     JoinedWithSameExpansion(Vec<RepackOp<'tcx>>),
     CreatedExpansion(Vec<RepackOp<'tcx>>),
     JoinedWithOtherExpansions(JoinDifferentExpansionsResult<'tcx>),
-    CollapsedOtherExpansion,
+    CollapsedOtherExpansion(Vec<RepackOp<'tcx>>),
 }
 
 impl<'tcx> JoinExpandedPlaceResult<'tcx> {
     fn actions(self) -> Vec<RepackOp<'tcx>> {
         match self {
             JoinExpandedPlaceResult::JoinedWithSameExpansion(actions)
-            | JoinExpandedPlaceResult::CreatedExpansion(actions) => actions,
+            | JoinExpandedPlaceResult::CreatedExpansion(actions)
+            | JoinExpandedPlaceResult::CollapsedOtherExpansion(actions) => actions,
             JoinExpandedPlaceResult::JoinedWithOtherExpansions(result) => result.actions(),
-            JoinExpandedPlaceResult::CollapsedOtherExpansion => vec![],
         }
     }
 
@@ -63,7 +63,7 @@ impl<'tcx> JoinExpandedPlaceResult<'tcx> {
             self,
             JoinExpandedPlaceResult::JoinedWithOtherExpansions(
                 JoinDifferentExpansionsResult::Collapsed(_)
-            ) | JoinExpandedPlaceResult::CollapsedOtherExpansion
+            ) | JoinExpandedPlaceResult::CollapsedOtherExpansion(_)
         )
     }
 }
@@ -237,11 +237,29 @@ impl<'pcg, 'a: 'pcg, 'tcx> JoinOwnedData<'a, 'pcg, 'tcx, &'pcg mut LocalExpansio
             } else if other_expansion.is_enum_expansion() {
                 // The other expansion is a downcast to a variant that is
                 // presumably borrowed or partially-moved (see 206_issue_77.rs).
-                // It won't survive the join, so collapse it.
-                other
-                    .owned
-                    .collapse(place, Some(CapabilityKind::Write), other.capabilities, ctxt);
-                Ok(JoinExpandedPlaceResult::CollapsedOtherExpansion)
+                // It won't survive the join, so collapse it, announcing the
+                // ops: leaves still above write capability are weakened
+                // first, so that the emitted collapse meets its guarantee
+                // that all packed-up places hold exactly its capability.
+                let mut ops: Vec<RepackOp<'tcx>> = other
+                    .capabilities
+                    .owned_capabilities(place.local, ctxt)
+                    .filter_map(|(p, k)| {
+                        (place.is_prefix_of(p) && *k > CapabilityKind::Write).then(|| {
+                            let weaken =
+                                RepackOp::Weaken(Weaken::new(p, *k, CapabilityKind::Write));
+                            *k = CapabilityKind::Write;
+                            weaken
+                        })
+                    })
+                    .collect();
+                ops.extend(other.owned.collapse(
+                    place,
+                    Some(CapabilityKind::Write),
+                    other.capabilities,
+                    ctxt,
+                ));
+                Ok(JoinExpandedPlaceResult::CollapsedOtherExpansion(ops))
             } else {
                 // We might as well just expand our place
                 let expand_action = RepackExpand::new(place, other_expansion.guide(), self_cap);

--- a/test-files/229_join_variant_collapse.rs
+++ b/test-files/229_join_variant_collapse.rs
@@ -1,0 +1,25 @@
+struct A(u32);
+struct B {
+    f: A,
+    g: A,
+}
+enum E {
+    V(B),
+    N,
+}
+
+// A join of a path that partially moved out of an enum variant with a path
+// that left the local packed must announce, on the deep path's edge, the
+// weakens of the still-exclusive leaves and the collapse chain back up to
+// the local; the local stays live so nothing collapses it earlier.
+fn repro(mut x: E, y: E) {
+    if let E::V(B { f: z, .. }) = x {}
+    // PCG: bb2 -> bb4: Weaken(Weaken { place: (_1@V).0.1, from: E, to: W, for_storage_dead: false, _marker: PhantomData<&()> })
+    // PCG: bb2 -> bb4: Collapse(RepackCollapse { to: (_1@V).0, capability: W, guide: None, _marker: PhantomData<&()> })
+    // PCG: bb2 -> bb4: Collapse(RepackCollapse { to: (_1@V), capability: W, guide: None, _marker: PhantomData<&()> })
+    // PCG: bb2 -> bb4: Collapse(RepackCollapse { to: _1, capability: W, guide: Some(Downcast(Some("V"), 0)), _marker: PhantomData<&()> })
+    // PCG: bb3 -> bb4: Weaken(Weaken { place: _1, from: E, to: W, for_storage_dead: false, _marker: PhantomData<&()> })
+    x = y;
+}
+
+fn main() {}


### PR DESCRIPTION
When a path that unpacked an enum variant (e.g. a partial move out of the variant's payload) joins a path where the local is packed, the variant expansion cannot survive the join and is collapsed -- but the repack ops were discarded, so consumers bridging that edge saw no ops at all while the joined state has the local packed at write capability (violating RepackOp's guarantee that packed-up places hold exactly the given capability). Return the ops instead, weakening still-exclusive leaves first so the emitted collapse meets that guarantee.

Observable via PCG_EMIT_ANNOTATIONS on the new test file: the deep path's edge previously emitted nothing; it now emits the leaf weaken and the collapse chain up through the downcast.

Does the pcg not have a "symbolic execution" test thing, where it steps through the program and executes the MIR according to the triples and executes the pcg statements but does no repacking of its own? I feel like that would catch issues like this.