### PR TITLE
Track lent-through references as `ShallowExclusive` and announce all value drops

### DIFF
--- a/src/owned_pcg/impl/local/join.rs
+++ b/src/owned_pcg/impl/local/join.rs
@@ -400,11 +400,43 @@ impl<'pcg, 'a: 'pcg, 'tcx> JoinOwnedData<'a, 'pcg, 'tcx, &'pcg mut LocalExpansio
                 }
                 Ok(vec![])
             }
-            (CapabilityKind::Read | CapabilityKind::Write | CapabilityKind::Exclusive, _)
-            | (CapabilityKind::ShallowExclusive, CapabilityKind::ShallowExclusive) => Ok(vec![]),
-            (CapabilityKind::ShallowExclusive, _) => {
-                todo!()
+            (CapabilityKind::ShallowExclusive, CapabilityKind::Write) => {
+                // A reference lent through on this side but moved out on the
+                // other: the joined state can only be Write, so the value
+                // still held here must be dropped. Label the place so that
+                // borrow-machinery references to its old value resolve to
+                // this join point (where the value was last held), then
+                // announce the weaken.
+                let mut join_obtainer = JoinObtainer {
+                    ctxt,
+                    data: self,
+                    actions: vec![],
+                };
+                let action = BorrowPcgAction::label_place_and_update_related_capabilities(
+                    place,
+                    join_obtainer.prev_snapshot_location(),
+                    LabelPlaceReason::JoinOwnedReadAndWriteCapabilities,
+                );
+                join_obtainer.apply_action(PcgAction::Borrow(action))?;
+                join_obtainer
+                    .data
+                    .capabilities
+                    .insert(place, CapabilityKind::Write, ctxt);
+                let mut actions = join_obtainer.actions;
+                actions.push(RepackOp::weaken(
+                    place,
+                    CapabilityKind::ShallowExclusive,
+                    CapabilityKind::Write,
+                ));
+                Ok(actions)
             }
+            (
+                CapabilityKind::Read
+                | CapabilityKind::Write
+                | CapabilityKind::Exclusive
+                | CapabilityKind::ShallowExclusive,
+                _,
+            ) => Ok(vec![]),
         }
     }
 

--- a/src/owned_pcg/impl/local/join.rs
+++ b/src/owned_pcg/impl/local/join.rs
@@ -5,7 +5,7 @@ use crate::{
     capability_gte,
     error::PcgError,
     owned_pcg::{
-        ExpandedPlace, LocalExpansions, RepackExpand, RepackOp,
+        ExpandedPlace, LocalExpansions, RegainedCapability, RepackExpand, RepackOp,
         join::{
             data::JoinOwnedData,
             obtain::{JoinCtxt, JoinObtainer},
@@ -365,7 +365,21 @@ impl<'pcg, 'a: 'pcg, 'tcx> JoinOwnedData<'a, 'pcg, 'tcx, &'pcg mut LocalExpansio
             .data
             .capabilities
             .insert(place, CapabilityKind::Write, ctxt);
-        Ok(join_obtainer.actions)
+        let mut actions = join_obtainer.actions;
+        // This side's read-lending has ended and the value it still holds is
+        // dropped by the join (the other side moved it out): restore the
+        // place to exclusive and then weaken it, so consumers see a
+        // capability restoration followed by an ordinary value drop.
+        actions.push(RepackOp::RegainLoanedCapability(RegainedCapability::new(
+            place,
+            CapabilityKind::Exclusive,
+        )));
+        actions.push(RepackOp::weaken(
+            place,
+            CapabilityKind::Exclusive,
+            CapabilityKind::Write,
+        ));
+        Ok(actions)
     }
 
     pub(crate) fn join_owned_places(

--- a/src/owned_pcg/impl/local/join.rs
+++ b/src/owned_pcg/impl/local/join.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DebugLines, Weaken,
+    DebugLines,
     action::{BorrowPcgAction, PcgAction},
     borrow_pcg::action::LabelPlaceReason,
     capability_gte,
@@ -246,8 +246,7 @@ impl<'pcg, 'a: 'pcg, 'tcx> JoinOwnedData<'a, 'pcg, 'tcx, &'pcg mut LocalExpansio
                     .owned_capabilities(place.local, ctxt)
                     .filter_map(|(p, k)| {
                         (place.is_prefix_of(p) && *k > CapabilityKind::Write).then(|| {
-                            let weaken =
-                                RepackOp::Weaken(Weaken::new(p, *k, CapabilityKind::Write));
+                            let weaken = RepackOp::weaken(p, *k, CapabilityKind::Write);
                             *k = CapabilityKind::Write;
                             weaken
                         })

--- a/src/owned_pcg/results/repacks.rs
+++ b/src/owned_pcg/results/repacks.rs
@@ -7,7 +7,7 @@
 use std::marker::PhantomData;
 
 use crate::{
-    Weaken,
+    Weaken, pcg_validity_assert,
     rustc_interface::middle::mir::{self, PlaceElem},
 };
 
@@ -422,6 +422,17 @@ impl<Place> RegainedCapability<Place> {
     pub fn new(place: Place, capability: CapabilityKind) -> Self {
         Self { place, capability }
     }
+
+    pub fn place(&self) -> Place
+    where
+        Place: Copy,
+    {
+        self.place
+    }
+
+    pub fn capability(&self) -> CapabilityKind {
+        self.capability
+    }
 }
 
 impl<'a, 'tcx: 'a, Ctxt: HasCompilerCtxt<'a, 'tcx>> DebugRepr<Ctxt>
@@ -483,6 +494,15 @@ impl<Ctxt, P: std::fmt::Debug + DisplayWithCtxt<Ctxt>> DisplayWithCtxt<Ctxt>
 }
 
 impl<'tcx> RepackOp<'tcx> {
+    /// Create a Weaken, checking that it strictly reduces the capability.
+    pub(crate) fn weaken(place: Place<'tcx>, from: CapabilityKind, to: CapabilityKind) -> Self {
+        pcg_validity_assert!(
+            from > to,
+            "a weaken must strictly reduce the capability ({from:?} -> {to:?})"
+        );
+        Self::Weaken(Weaken::new(place, from, to))
+    }
+
     /// Temporary: create a Weaken for `StorageDead`.
     /// Required until <https://github.com/prusti/pcg/issues/137> is resolved.
     pub(crate) fn weaken_for_storage_dead(
@@ -490,6 +510,10 @@ impl<'tcx> RepackOp<'tcx> {
         from: CapabilityKind,
         to: CapabilityKind,
     ) -> Self {
+        pcg_validity_assert!(
+            from > to,
+            "a weaken must strictly reduce the capability ({from:?} -> {to:?})"
+        );
         Self::Weaken(Weaken::new_for_storage_dead(place, from, to))
     }
     pub(crate) fn expand<'a>(

--- a/src/pcg/domain/pcg.rs
+++ b/src/pcg/domain/pcg.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-    DebugLines, Weaken,
+    DebugLines,
     borrow_pcg::{
         edge::{borrow::BorrowEdge, kind::BorrowPcgEdgeKind},
         graph::{BorrowsGraph, join::JoinBorrowsArgs},
@@ -321,6 +321,25 @@ impl<'a, 'tcx: 'a> Pcg<'a, 'tcx> {
         &self.place_capabilities
     }
 
+    /// The tracked capability of `place`, if any (only leaves of the current
+    /// pack state have entries).
+    pub fn place_capability<'b>(
+        &self,
+        place: Place<'tcx>,
+        ctxt: impl HasBorrowCheckerCtxt<'b, 'tcx>,
+    ) -> Option<CapabilityKind>
+    where
+        'tcx: 'b,
+    {
+        self.place_capabilities.get(place, ctxt)
+    }
+
+    /// Whether `local` is allocated and currently unpacked into sub-places.
+    #[must_use]
+    pub fn local_is_expanded(&self, local: mir::Local) -> bool {
+        self.owned.is_allocated(local) && self.owned[local].expansions().has_expansions()
+    }
+
     pub(crate) fn borrow_created_at(&self, location: mir::Location) -> Option<&BorrowEdge<'tcx>> {
         self.borrow.graph().borrow_created_at(location)
     }
@@ -400,7 +419,7 @@ impl<'a, 'tcx: 'a> Pcg<'a, 'tcx> {
             if let Some(other_cap) = other.place_capabilities.get(place, ctxt)
                 && cap > other_cap
             {
-                repacks.push(RepackOp::Weaken(Weaken::new(place, cap, other_cap)));
+                repacks.push(RepackOp::weaken(place, cap, other_cap));
             }
         }
         Ok(repacks)

--- a/src/pcg/place_capabilities.rs
+++ b/src/pcg/place_capabilities.rs
@@ -163,7 +163,10 @@ impl<'a, 'tcx: 'a> PlaceCapabilities<'tcx> {
                 ctxt,
             );
         } else {
-            self.insert(ref_place, CapabilityKind::Write, ctxt);
+            // The reference itself is still fully accessible (its pointer
+            // value remains readable and overwritable); only the permission
+            // *through* the dereference is given up.
+            self.insert(ref_place, CapabilityKind::ShallowExclusive, ctxt);
             self.insert(
                 ref_place.project_deref(ctxt.bc_ctxt()),
                 CapabilityKind::Exclusive,
@@ -252,7 +255,7 @@ impl<'a, 'tcx: 'a, Ctxt: HasCompilerCtxt<'a, 'tcx> + HasSettings<'a> + DebugCtxt
                 ctxt: Ctxt,
             ) -> bool {
                 match (parent_cap, child_cap) {
-                    (CapabilityKind::Write, _)
+                    (CapabilityKind::Write | CapabilityKind::ShallowExclusive, _)
                         if parent_place.ref_mutability(ctxt).is_some()
                             || parent_place.is_raw_ptr(ctxt) =>
                     {
@@ -303,7 +306,9 @@ impl<'a, 'tcx: 'a, Ctxt: HasCompilerCtxt<'a, 'tcx> + HasSettings<'a> + DebugCtxt
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum BlockType {
     /// Derefing a mutable reference, *not* in the context of a two-phase borrow
-    /// of otherwise just for read. The reference will be downgraded to w.
+    /// of otherwise just for read. The reference will be downgraded to e
+    /// (its own cell stays accessible; only the permission through the deref
+    /// is given up).
     DerefMutRefForExclusive,
     /// Dereferencing a mutable reference that is stored under a shared borrow
     DerefMutRefUnderSharedRef,
@@ -316,7 +321,7 @@ impl BlockType {
     pub(crate) fn blocked_place_maximum_retained_capability(self) -> Option<CapabilityKind> {
         match self {
             BlockType::DerefSharedRef => Some(CapabilityKind::Exclusive),
-            BlockType::DerefMutRefForExclusive => Some(CapabilityKind::Write),
+            BlockType::DerefMutRefForExclusive => Some(CapabilityKind::ShallowExclusive),
             BlockType::DerefMutRefUnderSharedRef | BlockType::Read => Some(CapabilityKind::Read),
             BlockType::Other => None,
         }

--- a/src/pcg/visitor/obtain.rs
+++ b/src/pcg/visitor/obtain.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "visualization")]
 use crate::visualization::stmt_graphs;
 use crate::{
-    HasSettings, Weaken,
+    HasSettings,
     action::{AppliedAction, BorrowPcgAction, OwnedPcgAction, PcgAction},
     borrow_pcg::{
         self,
@@ -656,6 +656,31 @@ impl<'state, 'a: 'state, 'tcx: 'a, Ctxt: DataflowCtxt<'a, 'tcx>>
             } else {
                 obtain_cap
             };
+            // When collapsing to write capability (an overwrite or a
+            // StorageDead of e.g. a partially-moved local), leaves that still
+            // hold exclusive capability must be explicitly weakened first, so
+            // that consumers see the capability drop; see
+            // <https://github.com/prusti/pcg/issues/137>.
+            if collapse_cap.is_write() {
+                let to_weaken = self
+                    .pcg
+                    .place_capabilities
+                    .owned_capabilities(place.local, self.ctxt)
+                    .filter_map(|(p, k)| {
+                        (place.is_prefix_of(p) && k.is_exclusive()).then_some((p, *k))
+                    })
+                    .collect::<Vec<_>>();
+                for (p, from_cap) in to_weaken {
+                    let weaken = if obtain_type == ObtainType::ForStorageDead {
+                        RepackOp::weaken_for_storage_dead(p, from_cap, CapabilityKind::Write)
+                    } else {
+                        RepackOp::weaken(p, from_cap, CapabilityKind::Write)
+                    };
+                    self.record_and_apply_action(PcgAction::Owned(OwnedPcgAction::new(
+                        weaken, None,
+                    )))?;
+                }
+            }
             tracing::debug!(
                 "Collapsing owned places to {}",
                 place.display_string(self.ctxt.bc_ctxt())
@@ -725,11 +750,11 @@ impl<'state, 'a: 'state, 'tcx: 'a, Ctxt: DataflowCtxt<'a, 'tcx>>
             // Temporary: mark as for_storage_dead until
             // https://github.com/prusti/pcg/issues/137 is resolved.
             self.record_and_apply_action(PcgAction::Owned(OwnedPcgAction::new(
-                RepackOp::Weaken(Weaken::new_for_storage_dead(
+                RepackOp::weaken_for_storage_dead(
                     place,
                     CapabilityKind::Exclusive,
                     CapabilityKind::Write,
-                )),
+                ),
                 None,
             )))?;
         }

--- a/src/pcg/visitor/obtain.rs
+++ b/src/pcg/visitor/obtain.rs
@@ -130,11 +130,13 @@ impl<'state, 'a: 'state, 'tcx: 'a, Ctxt: DataflowCtxt<'a, 'tcx>>
         };
 
         // The blocked capability would be None if the place was mutably
-        // borrowed The capability would be Write if the place is a
-        // mutable reference (when dereferencing a mutable ref, the ref
-        // place retains write capability)
-        if matches!(blocked_cap, None | Some(CapabilityKind::Write))
-            && blocked_cap != Some(restore_cap)
+        // borrowed. The capability would be ShallowExclusive if the place is
+        // a mutable reference (when dereferencing a mutable ref, the ref
+        // place retains shallow-exclusive capability).
+        if matches!(
+            blocked_cap,
+            None | Some(CapabilityKind::Write | CapabilityKind::ShallowExclusive)
+        ) && blocked_cap != Some(restore_cap)
         {
             self.record_and_apply_action(PcgAction::restore_capability(
                 place,
@@ -667,7 +669,8 @@ impl<'state, 'a: 'state, 'tcx: 'a, Ctxt: DataflowCtxt<'a, 'tcx>>
                     .place_capabilities
                     .owned_capabilities(place.local, self.ctxt)
                     .filter_map(|(p, k)| {
-                        (place.is_prefix_of(p) && k.is_exclusive()).then_some((p, *k))
+                        (place.is_prefix_of(p) && (k.is_exclusive() || k.is_shallow_exclusive()))
+                            .then_some((p, *k))
                     })
                     .collect::<Vec<_>>();
                 for (p, from_cap) in to_weaken {
@@ -743,18 +746,13 @@ impl<'state, 'a: 'state, 'tcx: 'a, Ctxt: DataflowCtxt<'a, 'tcx>>
         self.expand_to(place, obtain_type, self.ctxt)?;
 
         if obtain_type == ObtainType::ForStorageDead
-            && self
-                .pcg
-                .place_capability_equals(place, CapabilityKind::Exclusive, self.ctxt)
+            && let Some(cap @ (CapabilityKind::Exclusive | CapabilityKind::ShallowExclusive)) =
+                self.pcg.capability_of(place, self.ctxt)
         {
             // Temporary: mark as for_storage_dead until
             // https://github.com/prusti/pcg/issues/137 is resolved.
             self.record_and_apply_action(PcgAction::Owned(OwnedPcgAction::new(
-                RepackOp::weaken_for_storage_dead(
-                    place,
-                    CapabilityKind::Exclusive,
-                    CapabilityKind::Write,
-                ),
+                RepackOp::weaken_for_storage_dead(place, cap, CapabilityKind::Write),
                 None,
             )))?;
         }

--- a/src/pcg/visitor/upgrade.rs
+++ b/src/pcg/visitor/upgrade.rs
@@ -33,7 +33,7 @@ impl<'state, 'a: 'state, 'tcx: 'a, Ctxt: DataflowCtxt<'a, 'tcx> + DebugCtxt>
     ) -> Result<(), PcgError> {
         if place.is_mut_ref(self.ctxt) {
             // We've reached an indirection (e.g from **s to *s), we
-            // downgrade the ref from R to W
+            // downgrade the ref from R to e (lent through)
             // We need to continue: `s` would previously have capability R, which
             // is not compatible with it being mutably borrowed
             self.record_and_apply_action(


### PR DESCRIPTION
Consumers that do exact resource accounting need two guarantees from the PCG's output that previously did not hold: `Write` capability must unambiguously mean "the place holds no value", and every transition into `Write` must be announced as an op on the statement or edge where it happens.

## Changes

- **Weaken still-exclusive leaves when collapsing to write capability** (`obtain` step 2): a collapse-to-`W` (an overwrite, or `StorageDead` of e.g. a partially-moved local) now emits `Weaken(E→W)` for each leaf that still holds its value, so the emitted `Collapse` meets its guarantee that all packed-up places hold exactly the given capability. Related to #137.

- **Downgrade a mutably-derefed reference to `ShallowExclusive`, not `Write`**: a reference whose pointee is reborrowed still holds its own value (the pointer stays readable and overwritable); only the permission *through* the dereference is given up, which is exactly `ShallowExclusive`. All transitions out of `e` are announced: overwrites and storage-deads weaken `e→W`, and loan expiry restores from `e`. This also resolves the previous `todo!()` in the `(e, _)` join arms.

- **Announce value drops at CFG joins**: joining a lent-through (`e`) or read (`R`) place with a side that moved the value out now labels the place (so labelled reads resolve to the join point) and announces the drop instead of performing it silently: the `e` side emits `Weaken(e→W)`, and the `R` side emits a restore to `E` followed by an ordinary `Weaken(E→W)`. Owned weakens are now constructed through checked helpers that assert the capability strictly decreases, upholding `RepackOp::Weaken`'s `_.1 > _.2` guarantee.